### PR TITLE
feat: Implementa rastreamento de eventos do Pixel da Meta com ID final

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,11 +37,11 @@
     t.src=v;s=b.getElementsByTagName(e)[0];
     s.parentNode.insertBefore(t,s)}(window, document,'script',
     'https://connect.facebook.net/en_US/fbevents.js');
-    fbq('init', 'YOUR_PIXEL_ID_HERE');
+    fbq('init', '2017057495710555');
     fbq('track', 'PageView');
     </script>
     <noscript><img height="1" width="1" style="display:none"
-    src="https://www.facebook.com/tr?id=YOUR_PIXEL_ID_HERE&ev=PageView&noscript=1"
+    src="https://www.facebook.com/tr?id=2017057495710555&ev=PageView&noscript=1"
     /></noscript>
     <!-- End Meta Pixel Code -->
 </head>

--- a/obrigado.html
+++ b/obrigado.html
@@ -127,11 +127,11 @@
     t.src=v;s=b.getElementsByTagName(e)[0];
     s.parentNode.insertBefore(t,s)}(window, document,'script',
     'https://connect.facebook.net/en_US/fbevents.js');
-    fbq('init', 'YOUR_PIXEL_ID_HERE');
+    fbq('init', '2017057495710555');
     fbq('track', 'PageView');
     </script>
     <noscript><img height="1" width="1" style="display:none"
-    src="https://www.facebook.com/tr?id=YOUR_PIXEL_ID_HERE&ev=PageView&noscript=1"
+    src="https://www.facebook.com/tr?id=2017057495710555&ev=PageView&noscript=1"
     /></noscript>
     <!-- End Meta Pixel Code -->
 </head>


### PR DESCRIPTION
Atualiza a implementação do Pixel da Meta com o ID de Pixel (`2017057495710555`) fornecido pelo usuário.

Esta alteração finaliza a configuração do rastreamento de eventos, garantindo que os dados sejam enviados para a conta de anúncios correta da Meta.

A implementação inclui os seguintes eventos:
- `PageView`
- `ViewContent`
- `AddToCart`
- `InitiateCheckout`
- `Purchase`